### PR TITLE
Generate pyplot directory with Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ MAIN = main
 MAIN_OBJECTS = main.o graph.o parse.o stat.o basicstat.o connectstat.o countstat.o makeplot.o html.o
 TEST = test
 TEST_OBJECTS = test.o graph.o parse.o diameter.o
+PYPLOT_DIR = pyplot
 CXXFLAGS = -std=c++11 -Wall -O3
 LDFLAGS =
 
-all: $(MAIN) $(TEST)
+all: $(MAIN) $(TEST) $(PYPLOT_DIR)
 
 $(MAIN): $(MAIN_OBJECTS)
 	$(CXX) -o $@ $^ $(LDFLAGS)
@@ -14,5 +15,8 @@ $(MAIN): $(MAIN_OBJECTS)
 $(TEST): $(TEST_OBJECTS)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 
+$(PYPLOT_DIR):
+	mkdir -p pyplot
+
 clean:
-	rm -rf $(MAIN) $(MAIN_OBJECTS) $(TEST) $(TEST_OBJECTS) *.html pyplot/*.png __pycache__
+	rm -rf $(MAIN) $(MAIN_OBJECTS) $(TEST) $(TEST_OBJECTS) *.html pyplot __pycache__


### PR DESCRIPTION
The current code breaks when the `pyplot` directory doesn't exist, so create it with the Makefile (temporary workaround).