### PR TITLE
Implement verification of results

### DIFF
--- a/basicstat.cpp
+++ b/basicstat.cpp
@@ -5,7 +5,7 @@ std::string BasicStat::statName() {
     return "BasicStat";
 }
 
-bool BasicStat::calculateStat(Graph &graph) {
+bool BasicStat::calculateStat(Graph &graph, bool verify) {
     const DSGraph *dsgraph = dynamic_cast<const DSGraph *>(&graph);
     const USGraph *usgraph = dynamic_cast<const USGraph *>(&graph);
 

--- a/basicstat.h
+++ b/basicstat.h
@@ -12,7 +12,7 @@ class BasicStat : public CommonStat {
     virtual std::string statName() override;
 
    protected:
-    virtual bool calculateStat(Graph &graph) override;
+    virtual bool calculateStat(Graph &graph, bool verify) override;
     virtual void writeToHTMLStat(FILE *fp, bool directed) override;
 
    private:

--- a/betweennesscentrality.cpp
+++ b/betweennesscentrality.cpp
@@ -13,7 +13,7 @@ std::string BetweennessCentrality::statName() {
     return "BetweennessCentrality";
 }
 
-bool BetweennessCentrality::calculateStat(Graph &graph) {
+bool BetweennessCentrality::calculateStat(Graph &graph, bool verify) {
     const auto &vertices = graph.id_to_vertex;
     int V = vertices.size();
     int sample_sz = std::min(V, MAX_BETWEENNESS_SAMPLE_SZ);

--- a/betweennesscentrality.h
+++ b/betweennesscentrality.h
@@ -14,7 +14,7 @@ class BetweennessCentrality : public CommonStat {
     virtual std::string statName() override;
 
    protected:
-    virtual bool calculateStat(Graph &graph) override;
+    virtual bool calculateStat(Graph &graph, bool verify) override;
     virtual void writeToHTMLStat(FILE *fp, bool directed) override;
     virtual bool writeToFileStat(std::string graph_name, bool directed) override;
 

--- a/biconnected.cpp
+++ b/biconnected.cpp
@@ -144,7 +144,7 @@ void BiconnectedComponents::resetVisited(USGraph &graph) {
     }
 }
 
-// verify that the articulation points are correct
+// verify that the articulation points are correct, O(V^2) (slow!)
 bool BiconnectedComponents::verifyArticulationPoints(USGraph &graph) {
     // assume metadata is properly initialized
 

--- a/biconnected.cpp
+++ b/biconnected.cpp
@@ -22,6 +22,7 @@ static VertexMetadata *getMetadata(Graph::Vertex *v) {
 }
 
 bool BiconnectedComponents::calculateUndirectedStat(USGraph &graph, bool verify) {
+    bool success = true;
     for (auto &pair : graph.id_to_vertex) {
         pair.second->temp = new VertexMetadata();
     }
@@ -43,10 +44,15 @@ bool BiconnectedComponents::calculateUndirectedStat(USGraph &graph, bool verify)
         }
     }
 
+    if (verify) {
+        success = verifyArticulationPoints(graph);
+    }
+
     for (auto &pair : graph.id_to_vertex) {
         delete getMetadata(pair.second);
     }
-    return true;
+
+    return success;
 }
 
 void BiconnectedComponents::writeToHTMLStat(FILE *fp, bool directed) {
@@ -130,5 +136,63 @@ void BiconnectedComponents::countBcc(USGraph &graph) {
             }
         }
     }
+}
+
+void BiconnectedComponents::resetVisited(USGraph &graph) {
+    for (auto &pair : graph.id_to_vertex) {
+        getMetadata(pair.second)->visited = false;
+    }
+}
+
+// verify that the articulation points are correct
+bool BiconnectedComponents::verifyArticulationPoints(USGraph &graph) {
+    // assume metadata is properly initialized
+
+    std::vector<Graph::Vertex *> dfs_stack;
+
+    for (auto &pair : graph.id_to_vertex) {
+        Graph::Vertex *root = pair.second;
+        VertexMetadata *root_meta = getMetadata(root);
+        if (root->edges.empty()) {
+            continue; // do not consider non-connected vertices as of now
+        }
+        // perform dfs on each vertex connected to the root
+        resetVisited(graph);
+        dfs_stack.clear();
+        root_meta->visited = true;
+
+        long long true_bcc_count = 0;
+        for (auto &root_edge : root->edges) {
+            Graph::Vertex *root_vertex = root_edge->to == root ? root_edge->from : root_edge->to;
+            VertexMetadata *rv_meta = getMetadata(root_vertex);
+            if (rv_meta->visited) { // already visited from a previous bcc probe
+                continue;
+            } else {
+                true_bcc_count++;
+                // perform dfs on the vertex
+                dfs_stack.push_back(root_vertex);
+                while (!dfs_stack.empty()) {
+                    Graph::Vertex *v = dfs_stack.back();
+                    dfs_stack.pop_back();
+
+                    VertexMetadata *meta = getMetadata(v);
+                    meta->visited = true;
+
+                    for (auto &e : v->edges) {
+                        Graph::Vertex *to = e->to == v ? e->from : e->to;
+                        VertexMetadata *to_meta = getMetadata(to);
+                        if (!to_meta->visited) {
+                            dfs_stack.push_back(to);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (true_bcc_count != root_meta->num_connected_bcc) {
+            return false;
+        }
+    }
+    return true;
 }
 }  // namespace snu

--- a/biconnected.cpp
+++ b/biconnected.cpp
@@ -21,7 +21,7 @@ static VertexMetadata *getMetadata(Graph::Vertex *v) {
     return (VertexMetadata *)v->temp;
 }
 
-bool BiconnectedComponents::calculateUndirectedStat(USGraph &graph) {
+bool BiconnectedComponents::calculateUndirectedStat(USGraph &graph, bool verify) {
     for (auto &pair : graph.id_to_vertex) {
         pair.second->temp = new VertexMetadata();
     }

--- a/biconnected.h
+++ b/biconnected.h
@@ -15,6 +15,8 @@ class BiconnectedComponents : public UndirectedStat {
 
    private:
     void countBcc(USGraph &graph);
+    void resetVisited(USGraph &graph);
+    bool verifyArticulationPoints(USGraph &graph);
 
     long long num_arp;       // number of articulation points
     long long num_bcc;       // number of biconnected components

--- a/biconnected.h
+++ b/biconnected.h
@@ -15,8 +15,8 @@ class BiconnectedComponents : public UndirectedStat {
 
    private:
     void countBcc(USGraph &graph);
-    void resetVisited(USGraph &graph);
-    bool verifyArticulationPoints(USGraph &graph);
+    void resetVisited(USGraph &graph); // reset visited
+    bool verifyArticulationPoints(USGraph &graph); // for verification, O(V^2)
 
     long long num_arp;       // number of articulation points
     long long num_bcc;       // number of biconnected components

--- a/biconnected.h
+++ b/biconnected.h
@@ -10,7 +10,7 @@ class BiconnectedComponents : public UndirectedStat {
     virtual std::string statName() override;
 
    protected:
-    virtual bool calculateUndirectedStat(USGraph &graph) override;
+    virtual bool calculateUndirectedStat(USGraph &graph, bool verify) override;
     virtual void writeToHTMLStat(FILE *fp, bool directed) override;
 
    private:

--- a/closenesscentrality.cpp
+++ b/closenesscentrality.cpp
@@ -14,7 +14,7 @@ std::string ClosenessCentrality::statName() {
     return "ClosenessCentrality";
 }
 
-bool ClosenessCentrality::calculateStat(Graph &graph) {
+bool ClosenessCentrality::calculateStat(Graph &graph, bool verify) {
     const auto &vertices = graph.id_to_vertex;
     int V = vertices.size();
     int sample_sz = std::min(V, MAX_CLOSENESS_SAMPLE_SZ);

--- a/closenesscentrality.h
+++ b/closenesscentrality.h
@@ -14,7 +14,7 @@ class ClosenessCentrality : public CommonStat {
     virtual std::string statName() override;
 
    protected:
-    virtual bool calculateStat(Graph &graph) override;
+    virtual bool calculateStat(Graph &graph, bool verify) override;
     virtual void writeToHTMLStat(FILE *fp, bool directed) override;
     virtual bool writeToFileStat(std::string graph_name, bool directed) override;
 

--- a/connectstat.cpp
+++ b/connectstat.cpp
@@ -208,7 +208,7 @@ std::string ConnectStat::statName() {
     return "ConnectStat";
 }
 
-bool ConnectStat::calculateStat(Graph &graph) {
+bool ConnectStat::calculateStat(Graph &graph, bool verify) {
     DSGraph *dsgraph = dynamic_cast<DSGraph *>(&graph);
     USGraph *usgraph = dynamic_cast<USGraph *>(&graph);
 

--- a/connectstat.h
+++ b/connectstat.h
@@ -13,7 +13,7 @@ class ConnectStat : public CommonStat {
     virtual std::string statName() override;
 
    protected:
-    virtual bool calculateStat(Graph &graph) override;
+    virtual bool calculateStat(Graph &graph, bool verify) override;
     virtual void writeToHTMLStat(FILE *fp, bool directed) override;
 
    private:

--- a/countstat.cpp
+++ b/countstat.cpp
@@ -7,7 +7,7 @@ std::string CountStat::statName() {
     return "CountStat";
 }
 
-bool CountStat::calculateUndirectedStat(USGraph &graph) {
+bool CountStat::calculateUndirectedStat(USGraph &graph, bool verify) {
     unsigned long long s = 0;
     unsigned long long z = 0;
 

--- a/countstat.h
+++ b/countstat.h
@@ -10,7 +10,7 @@ class CountStat : public UndirectedStat {
     virtual std::string statName() override;
 
    protected:
-    virtual bool calculateUndirectedStat(USGraph &graph) override;
+    virtual bool calculateUndirectedStat(USGraph &graph, bool verify) override;
     virtual void writeToHTMLStat(FILE *fp, bool directed) override;
 
    private:

--- a/eigencentrality.cpp
+++ b/eigencentrality.cpp
@@ -46,7 +46,7 @@ bool EigenCentrality::calculateStat(Graph &graph, bool verify) {
         }
     }
 
-    return true;
+    return eigencentrality_converged && pagerank_converged;
 }
 
 void EigenCentrality::writeToHTMLStat(FILE *fp, bool directed) {

--- a/eigencentrality.cpp
+++ b/eigencentrality.cpp
@@ -7,7 +7,7 @@ std::string EigenCentrality::statName() {
     return "EigenCentrality";
 }
 
-bool EigenCentrality::calculateStat(Graph &graph) {
+bool EigenCentrality::calculateStat(Graph &graph, bool verify) {
     std::vector<double> probv;
     probv.resize(graph.V);
 

--- a/eigencentrality.h
+++ b/eigencentrality.h
@@ -15,7 +15,7 @@ class EigenCentrality : public CommonStat {
     virtual std::string statName() override;
 
    protected:
-    virtual bool calculateStat(Graph &graph) override;
+    virtual bool calculateStat(Graph &graph, bool verify) override;
     virtual void writeToHTMLStat(FILE *fp, bool directed) override;
 
    private:

--- a/main.cpp
+++ b/main.cpp
@@ -24,6 +24,7 @@ int main(int argc, char *argv[]) {
     bool directed = false;     // suppose given graph is undirected.
     bool file_output = false;  // default: skip output of detailed files
     bool display_time = true;  // always: show time statistics
+    bool verify = false;       // verify results (default: skip verification)
 
     while (true) {
         static struct option long_options[] = {
@@ -31,9 +32,11 @@ int main(int argc, char *argv[]) {
             {"undirected", 0, NULL, 'u'},
             {"help", 0, NULL, 'h'},
             {"file_output", 0, NULL, 'f'},
-            {0, 0, 0, 0}};
+            {"verify", 0, NULL, 'v'},
+            {0, 0, 0, 0}
+        };
 
-        int option = getopt_long(argc, argv, "duhf", long_options, NULL);
+        int option = getopt_long(argc, argv, "duhfv", long_options, NULL);
 
         if (option < 0) {
             break;
@@ -50,6 +53,10 @@ int main(int argc, char *argv[]) {
 
             case 'f':
                 file_output = true;
+                break;
+
+            case 'v':
+                verify = true;
                 break;
 
             case 'h':
@@ -125,7 +132,7 @@ int main(int argc, char *argv[]) {
     };
 
     // run all stats using the graph
-    auto analyzer = snu::StatAnalyzer(graph_name, graph_shptr, file_output, display_time);
+    auto analyzer = snu::StatAnalyzer(graph_name, graph_shptr, file_output, display_time, verify);
     analyzer.addCommonStats(common_stats);
     analyzer.addDirectedStats(directed_only_stats);
     analyzer.addUndirectedStats(undirected_only_stats);

--- a/stat.cpp
+++ b/stat.cpp
@@ -21,18 +21,18 @@ bool Stat::writeToFile(std::string graph_name, bool directed) {
     return false;
 }
 
-bool CommonStat::calculate(Graph &graph) {
-    success = calculateStat(graph);
+bool CommonStat::calculate(Graph &graph, bool verify) {
+    success = calculateStat(graph, verify);
     return success;
 }
 
-bool DirectedStat::calculateDirected(DSGraph &graph) {
-    success = calculateDirectedStat(graph);
+bool DirectedStat::calculateDirected(DSGraph &graph, bool verify) {
+    success = calculateDirectedStat(graph, verify);
     return success;
 }
 
-bool UndirectedStat::calculateUndirected(USGraph &graph) {
-    success = calculateUndirectedStat(graph);
+bool UndirectedStat::calculateUndirected(USGraph &graph, bool verify) {
+    success = calculateUndirectedStat(graph, verify);
     return success;
 }
 }  // namespace snu

--- a/stat.h
+++ b/stat.h
@@ -58,7 +58,7 @@
 
 namespace snu {
 class Stat {
-   public:
+public:
     // Name of the stat used for filenames, logs ...
     virtual std::string statName() = 0;
 
@@ -80,7 +80,7 @@ class Stat {
     // - Implemented in derived classes.
     // bool calculate(Graph &graph)
 
-   protected:
+protected:
     // Override this function to set behaviour of 'writeToHTML(...)'
     virtual void writeToHTMLStat(FILE *fp, bool directed) = 0;
 
@@ -91,37 +91,40 @@ class Stat {
 
 // stats that apply to both USGraph and DSGraph
 class CommonStat : public Stat {
-   public:
+public:
     // Analyze the graph and store the results.
-    // return value: true on success
-    bool calculate(Graph &graph);
+    // param verify: whether to check the results
+    // return value: true on success (if verification is enabled, true if verification passes)
+    bool calculate(Graph &graph, bool verify);
 
-   protected:
+protected:
     // Override this function to set behaviour of 'calculate(...)'
-    virtual bool calculateStat(Graph &graph) = 0;
+    virtual bool calculateStat(Graph &graph, bool verify) = 0;
 };
 
 // stats that apply to only DSGraph
 class DirectedStat : public Stat {
-   public:
+public:
     // Analyze the graph and store the results.
-    // return value: true on success
-    bool calculateDirected(DSGraph &graph);
+    // param verify: whether to check the results
+    // return value: true on success (if verification is enabled, true if verification passes)
+    bool calculateDirected(DSGraph &graph, bool verify);
 
-   protected:
+protected:
     // Override this function to set behaviour of 'calculateDirected(...)'
-    virtual bool calculateDirectedStat(DSGraph &graph) = 0;
+    virtual bool calculateDirectedStat(DSGraph &graph, bool verify) = 0;
 };
 
 class UndirectedStat : public Stat {
-   public:
+public:
     // Analyze the graph and store the results.
-    // return value: true on success
-    bool calculateUndirected(USGraph &graph);
+    // param verify: whether to check the results
+    // return value: true on success (if verification is enabled, true if verification passes)
+    bool calculateUndirected(USGraph &graph, bool verify);
 
-   protected:
+protected:
     // Override this function to set behaviour of 'calculateUndirected(...)'
-    virtual bool calculateUndirectedStat(USGraph &graph) = 0;
+    virtual bool calculateUndirectedStat(USGraph &graph, bool verify) = 0;
 };
 }  // namespace snu
 

--- a/statanalyzer.cpp
+++ b/statanalyzer.cpp
@@ -47,21 +47,27 @@ bool StatAnalyzer::run() {
 
     // calculate common stats
     for (auto commonStat : common_stats) {
-        commonStat->calculate(graph, verify);
+        if (!commonStat->calculate(graph, verify)) {
+            printf("%s failed\n", commonStat->statName().c_str());
+        }
         printElapsedTime(commonStat->statName().c_str(), t);
     }
 
     // calculate directed stats
     if (directed) {
         for (auto dirStat : directed_only_stats) {
-            dirStat->calculateDirected(*dsgraph_ptr, verify);
+            if (!dirStat->calculateDirected(*dsgraph_ptr, verify)) {
+                printf("%s failed\n", dirStat->statName().c_str());
+            }
             printElapsedTime(dirStat->statName().c_str(), t);
         }
     }
     // calculate undirected stats
     else {
         for (auto undirStat : undirected_only_stats) {
-            undirStat->calculateUndirected(*usgraph_ptr, verify);
+            if (!undirStat->calculateUndirected(*usgraph_ptr, verify)) {
+                printf("%s failed\n", undirStat->statName().c_str());
+            }
             printElapsedTime(undirStat->statName().c_str(), t);
         }
     }

--- a/statanalyzer.cpp
+++ b/statanalyzer.cpp
@@ -19,8 +19,9 @@ static void printElapsedTime(const char *msg, T &t) {
 StatAnalyzer::StatAnalyzer(std::string _graph_name,
                            std::shared_ptr<Graph> _graph_shptr,
                            bool _file_output,
-                           bool _display_time)
-    : graph_name(_graph_name), graph_shptr(_graph_shptr), file_output(_file_output), display_time(_display_time) {
+                           bool _display_time,
+                           bool _verify)
+    : graph_name(_graph_name), graph_shptr(_graph_shptr), file_output(_file_output), display_time(_display_time), verify(_verify) {
 }
 
 bool StatAnalyzer::run() {
@@ -46,21 +47,21 @@ bool StatAnalyzer::run() {
 
     // calculate common stats
     for (auto commonStat : common_stats) {
-        commonStat->calculate(graph);
+        commonStat->calculate(graph, verify);
         printElapsedTime(commonStat->statName().c_str(), t);
     }
 
     // calculate directed stats
     if (directed) {
         for (auto dirStat : directed_only_stats) {
-            dirStat->calculateDirected(*dsgraph_ptr);
+            dirStat->calculateDirected(*dsgraph_ptr, verify);
             printElapsedTime(dirStat->statName().c_str(), t);
         }
     }
     // calculate undirected stats
     else {
         for (auto undirStat : undirected_only_stats) {
-            undirStat->calculateUndirected(*usgraph_ptr);
+            undirStat->calculateUndirected(*usgraph_ptr, verify);
             printElapsedTime(undirStat->statName().c_str(), t);
         }
     }

--- a/statanalyzer.h
+++ b/statanalyzer.h
@@ -12,17 +12,18 @@
 
 namespace snu {
 class StatAnalyzer {
-   public:
+public:
     StatAnalyzer(std::string _graph_name,
                  std::shared_ptr<Graph> _graph_shptr,
                  bool _file_output,
-                 bool _display_time);
+                 bool _display_time,
+                 bool _verify);
     bool run();
     void addCommonStats(std::vector<CommonStat *> vec);
     void addDirectedStats(std::vector<DirectedStat *> vec);
     void addUndirectedStats(std::vector<UndirectedStat *> vec);
 
-   private:
+private:
     std::vector<CommonStat *> common_stats;
     std::vector<snu::DirectedStat *> directed_only_stats;
     std::vector<snu::UndirectedStat *> undirected_only_stats;
@@ -31,6 +32,7 @@ class StatAnalyzer {
     std::shared_ptr<Graph> graph_shptr;
     bool file_output;
     bool display_time;
+    bool verify;
 };
 }  // namespace snu
 


### PR DESCRIPTION
This feature can be enabled with the flag --verify (-v).
It is disabled by default because verification is often slower than computation itself