### PR TITLE
Implement Spearman's rank correlation coefficient

### DIFF
--- a/testers/test_correlation.py
+++ b/testers/test_correlation.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import math
 import sys
 
 # file[0]: file name, file[1]: column
@@ -34,6 +33,29 @@ def calc_correlation(data):
     r2 = b * (n * sumxy - sumx * sumy) / (n * sumy2 - sumy * sumy)
     return a, b, r2
 
+# input: list of 2-tuples sorted by the second item of each tuple
+# output: dictionary that contains the rank of each item
+# example:
+#     input: [(1, 3), (5, 4), (3, 4), (0, 6)]
+#     output: {1: 0, 5: 1.5, 3: 1.5, 0: 3}
+def key_to_rank(data):
+    ranks = dict() # calculate rank ranges (to handle ties correctly)
+    for i in range(len(data)):
+        if data[i][1] in ranks:
+            ranks[data[i][1]][1] = i
+        else:
+            ranks[data[i][1]] = [i, i]
+    return {k[0]: (ranks[k[1]][0] + ranks[k[1]][1]) * 0.5 for k in data}
+
+# Spearman's rank correlation coefficient (squared)
+# returns single value between 0 ~ 1
+def calc_spearman_rank_correlation(data):
+    # convert dictionaries to lists of 2-tuples (key, value) sorted by value
+    sorted_items = [sorted(a.items(), key = lambda x: x[1], reverse = True) for a in data]
+    # convert values to ranks
+    item_ranks = [key_to_rank(x) for x in sorted_items]
+    return calc_correlation(item_ranks)[2]
+
 if len(sys.argv) != 5:
     print('usage: test_correlation.py <file 1> <column> <file 2> <column>')
     print('example:')
@@ -48,7 +70,10 @@ data = [get_data(f) for f in files]
 
 a, b, r2 = calc_correlation(data)
 
+rho2 = calc_spearman_rank_correlation(data)
+
 print('y = a + b x')
 print(f'a = {a}')
 print(f'b = {b}')
 print(f'r^2 = {r2}')
+print(f"Spearman's rank correlation coefficient:\nrho^2 = {rho2}")


### PR DESCRIPTION
When comparing centrality measures, the relative ranking of each vertex is often more important than the absolute value of the centrality measure. The Spearman's rank correlation coefficient, which compares the ranks of two variables, can be used to validate the centrality rankings generated in this project.